### PR TITLE
updated gtf2bed.py to be able to handle GTF file with spaces in attribute's value

### DIFF
--- a/bin/gtf2bed.py
+++ b/bin/gtf2bed.py
@@ -47,8 +47,8 @@ with open(gtfFile, 'r') as f:
             attribute = re.sub("^\s*","",attribute)
             attribute = re.sub(r"\"","",attribute)
             if attribute != "":
-                key, value = attribute.split(' ')
-                attributeDict[key] = value
+                key, value = attribute.split(' "') #modified to address space in value e.g. "1 (assigned to previous version 2)" of key transcript_support_level
+                attributeDict[key] = value.replace('"','') #modified to remove closing double quoute
         if not attributeDict['transcript_id'] in entryDict:
             entryDict[attributeDict['transcript_id']] = list()
         entryDict[attributeDict['transcript_id']].append(line.rstrip())


### PR DESCRIPTION
in gtf2bed.py, modified string split on space to space and double quote for parsing the GRCm38 GTF file that has spaces in the attribute value for _transcript_support_level_.